### PR TITLE
There is a bug where only the first line coming through the output ge…

### DIFF
--- a/src/AspNetCore.VueCliServices/Util/EventedStreamReader.cs
+++ b/src/AspNetCore.VueCliServices/Util/EventedStreamReader.cs
@@ -4,6 +4,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -90,18 +91,9 @@ namespace Nyami.AspNetCore.VueCliServices.Util
 
                 OnChunk(new ArraySegment<char>(buf, 0, chunkLength));
 
-                var lineBreakPos = Array.IndexOf(buf, '\n', 0, chunkLength);
-                if (lineBreakPos < 0)
-                {
-                    _linesBuffer.Append(buf, 0, chunkLength);
-                }
-                else
-                {
-                    _linesBuffer.Append(buf, 0, lineBreakPos + 1);
-                    OnCompleteLine(_linesBuffer.ToString());
-                    _linesBuffer.Clear();
-                    _linesBuffer.Append(buf, lineBreakPos + 1, chunkLength - (lineBreakPos + 1));
-                }
+                _linesBuffer.Append(buf, 0, chunkLength);
+                OnCompleteLine(_linesBuffer.ToString());
+                _linesBuffer.Clear();
             }
         }
 

--- a/src/AspNetCore.VueCliServices/VueCliMiddleware.cs
+++ b/src/AspNetCore.VueCliServices/VueCliMiddleware.cs
@@ -16,7 +16,7 @@ namespace Nyami.AspNetCore.VueCliServices
     internal static class VueCliMiddleware
     {
         private const string LogCategoryName = "Nyami.AspNetCore.SpaServices";
-        private static TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(5); // This is a development-time only feature, so a very long timeout is fine
+        private static TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(60); // This is a development-time only feature, so a very long timeout is fine
 
         public static void Attach(
             ISpaBuilder spaBuilder,
@@ -69,7 +69,7 @@ namespace Nyami.AspNetCore.VueCliServices
                 try
                 {
                     openBrowserLine = await npmScriptRunner.StdOut.WaitForMatch(
-                         new Regex("  - Local:   (http\\S+)", RegexOptions.None, RegexMatchTimeout));
+                         new Regex("(.*)Local:(.*)", RegexOptions.None, RegexMatchTimeout));
                 }
                 catch (EndOfStreamException ex)
                 {
@@ -80,7 +80,7 @@ namespace Nyami.AspNetCore.VueCliServices
                 }
             }
 
-            var uri = new Uri(openBrowserLine.Groups[1].Value);
+            var uri = new Uri(openBrowserLine.Groups[2].Value);
             var serverInfo = new VueCliServerInfo { Port = uri.Port, Host = uri.Host, Scheme = uri.Scheme };
 
             // Even after the Vue CLI claims to be listening for requests, there may be a short


### PR DESCRIPTION
…ts processed for the string we're looking for. The code has been simplified to not worry about trying to chunk the output into discrete lines, because the regex really doesn't care.

Changed the regex to deal with the fact that it might be on top of another line